### PR TITLE
Add the meter fields the API returns but the struct dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Changes
 
+- Add the `kwh_scaling_factor`, `printed_full_serial_number` and `submeter` fields to `Discovergy.Meter`. The API returns them but they were silently dropped.
 - Bump dependencies
 
 ## v0.7.0 (2025-09-07)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@
 
 ### Changes
 
-- Add the `kwh_scaling_factor`, `printed_full_serial_number` and `submeter` fields to `Discovergy.Meter`. The API returns them but they were silently dropped.
+- Add the `kwh_scaling_factor`, `printed_full_serial_number`, `storage_numbers` and `submeter` fields to `Discovergy.Meter`. The API returns them but they were silently dropped.
+- Fix the `Discovergy.Measurement` typespec: `values` is a map, not a list of maps.
+- Document that the disaggregation endpoints reject intervals longer than one week.
 - Bump dependencies
 
 ## v0.7.0 (2025-09-07)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ iex> Discovergy.Metadata.get_meters(client)
   first_measurement_time: 1563286659367,
   full_serial_number: "1ESY1161229886",
   internal_meters: 1,
+  kwh_scaling_factor: 10000000000,
   last_measurement_time: 1593949473598,
   load_profile_type: "SLP",
   location: %Discovergy.Location{
@@ -50,8 +51,10 @@ iex> Discovergy.Metadata.get_meters(client)
   manufacturer_id: "ESY",
   measurement_type: "ELECTRICITY",
   meter_id: "c1972a89ce3a4d58aadcb7908a1d31c7",
+  printed_full_serial_number: "1ESY1161229886",
   scaling_factor: 1,
   serial_number: "61229886",
+  submeter: false,
   type: "EASYMETER",
   voltage_scaling_factor: 1
 }]}

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ iex> Discovergy.Metadata.get_meters(client)
   printed_full_serial_number: "1ESY1161229886",
   scaling_factor: 1,
   serial_number: "61229886",
+  storage_numbers: [1, 7, 14],
   submeter: false,
   type: "EASYMETER",
   voltage_scaling_factor: 1

--- a/lib/discovergy.ex
+++ b/lib/discovergy.ex
@@ -35,6 +35,7 @@ defmodule Discovergy do
         printed_full_serial_number: "1ESY1161229886",
         scaling_factor: 1,
         serial_number: "61229886",
+        storage_numbers: [1, 7, 14],
         submeter: false,
         type: "EASYMETER",
         voltage_scaling_factor: 1

--- a/lib/discovergy.ex
+++ b/lib/discovergy.ex
@@ -19,6 +19,7 @@ defmodule Discovergy do
         first_measurement_time: 1563286659367,
         full_serial_number: "1ESY1161229886",
         internal_meters: 1,
+        kwh_scaling_factor: 10000000000,
         last_measurement_time: 1593949473598,
         load_profile_type: "SLP",
         location: %Discovergy.Location{
@@ -31,8 +32,10 @@ defmodule Discovergy do
         manufacturer_id: "ESY",
         measurement_type: "ELECTRICITY",
         meter_id: "c1972a89ce3a4d58aadcb7908a1d31c7",
+        printed_full_serial_number: "1ESY1161229886",
         scaling_factor: 1,
         serial_number: "61229886",
+        submeter: false,
         type: "EASYMETER",
         voltage_scaling_factor: 1
       }]}

--- a/lib/discovergy/disaggregation.ex
+++ b/lib/discovergy/disaggregation.ex
@@ -10,6 +10,8 @@ defmodule Discovergy.Disaggregation do
   Provides the disaggregated energy for the specified meter at 15 minute
   intervals.
 
+  The API rejects intervals longer than one week with a `400`.
+
   ## Examples
 
       iex> Discovergy.Disaggregation.get_energy_by_device_measurements(
@@ -61,6 +63,8 @@ defmodule Discovergy.Disaggregation do
   @doc """
   Returns the activities recognised for the given meter during the given
   interval.
+
+  The API rejects intervals longer than one week with a `400`.
 
   ## Examples
 

--- a/lib/discovergy/metadata.ex
+++ b/lib/discovergy/metadata.ex
@@ -48,6 +48,7 @@ defmodule Discovergy.Metadata do
          current_scaling_factor: 1,
          voltage_scaling_factor: 1,
          kwh_scaling_factor: 10000000000,
+         storage_numbers: [1, 7, 14],
          submeter: false,
          internal_meters: 1,
          first_measurement_time: 1563286659367,

--- a/lib/discovergy/metadata.ex
+++ b/lib/discovergy/metadata.ex
@@ -32,6 +32,7 @@ defmodule Discovergy.Metadata do
          meter_id: "c1972a89ce3a4d58aadcb7908a1d31c7",
          serial_number: "61229886",
          full_serial_number: "1ESY1161229886",
+         printed_full_serial_number: "1ESY1161229886",
          location: %Discovergy.Location{
            city: "Greven",
            country: "DE",
@@ -46,6 +47,8 @@ defmodule Discovergy.Metadata do
          scaling_factor: 1,
          current_scaling_factor: 1,
          voltage_scaling_factor: 1,
+         kwh_scaling_factor: 10000000000,
+         submeter: false,
          internal_meters: 1,
          first_measurement_time: 1563286659367,
          last_measurement_time: 1593952103706,

--- a/lib/discovergy/models.ex
+++ b/lib/discovergy/models.ex
@@ -45,6 +45,7 @@ defmodule Discovergy.Meter do
           printed_full_serial_number: String.t(),
           scaling_factor: integer(),
           serial_number: String.t(),
+          storage_numbers: [integer],
           submeter: boolean,
           type: String.t(),
           voltage_scaling_factor: integer
@@ -68,6 +69,7 @@ defmodule Discovergy.Meter do
     :printed_full_serial_number,
     :scaling_factor,
     :serial_number,
+    :storage_numbers,
     :submeter,
     :type,
     :voltage_scaling_factor
@@ -106,7 +108,7 @@ defmodule Discovergy.Measurement do
 
   @type t :: %__MODULE__{
           time: DateTime.t(),
-          values: [map]
+          values: map
         }
 
   defstruct [:time, :values]

--- a/lib/discovergy/models.ex
+++ b/lib/discovergy/models.ex
@@ -35,14 +35,17 @@ defmodule Discovergy.Meter do
           first_measurement_time: non_neg_integer,
           full_serial_number: String.t(),
           internal_meters: non_neg_integer,
+          kwh_scaling_factor: integer,
           last_measurement_time: non_neg_integer,
           load_profile_type: String.t(),
           location: Discovergy.Location.t(),
           manufacturer_id: String.t(),
           measurement_type: String.t(),
           meter_id: String.t(),
+          printed_full_serial_number: String.t(),
           scaling_factor: integer(),
           serial_number: String.t(),
+          submeter: boolean,
           type: String.t(),
           voltage_scaling_factor: integer
         }
@@ -55,14 +58,17 @@ defmodule Discovergy.Meter do
     :first_measurement_time,
     :full_serial_number,
     :internal_meters,
+    :kwh_scaling_factor,
     :last_measurement_time,
     :load_profile_type,
     :location,
     :manufacturer_id,
     :measurement_type,
     :meter_id,
+    :printed_full_serial_number,
     :scaling_factor,
     :serial_number,
+    :submeter,
     :type,
     :voltage_scaling_factor
   ]
@@ -72,6 +78,8 @@ defmodule Discovergy.Meter do
     fields =
       Enum.map(attrs, fn
         {"location", location} -> {:location, Discovergy.Location.into(location)}
+        # Macro.underscore/1 turns this into "k_wh_scaling_factor"
+        {"kWhScalingFactor", value} -> {:kwh_scaling_factor, value}
         {key, value} -> camel_cased_key_to_existing_atom({key, value})
       end)
 

--- a/test/discovergy/metadata_test.exs
+++ b/test/discovergy/metadata_test.exs
@@ -36,6 +36,7 @@ defmodule Discovergy.MetadataTest do
             currentScalingFactor: 1,
             voltageScalingFactor: 1,
             kWhScalingFactor: 10_000_000_000,
+            storageNumbers: [1, 7, 14],
             submeter: false,
             internalMeters: 1,
             firstMeasurementTime: 1_563_286_659_367,
@@ -68,6 +69,7 @@ defmodule Discovergy.MetadataTest do
                 printed_full_serial_number: "1ESY1161229886",
                 scaling_factor: 1,
                 serial_number: "61229886",
+                storage_numbers: [1, 7, 14],
                 submeter: false,
                 type: "EASYMETER",
                 voltage_scaling_factor: 1

--- a/test/discovergy/metadata_test.exs
+++ b/test/discovergy/metadata_test.exs
@@ -20,6 +20,7 @@ defmodule Discovergy.MetadataTest do
             manufacturerId: "ESY",
             serialNumber: "61229886",
             fullSerialNumber: "1ESY1161229886",
+            printedFullSerialNumber: "1ESY1161229886",
             location: %{
               street: "Sedanstr.",
               streetNumber: "8",
@@ -34,6 +35,8 @@ defmodule Discovergy.MetadataTest do
             scalingFactor: 1,
             currentScalingFactor: 1,
             voltageScalingFactor: 1,
+            kWhScalingFactor: 10_000_000_000,
+            submeter: false,
             internalMeters: 1,
             firstMeasurementTime: 1_563_286_659_367,
             lastMeasurementTime: 1_594_130_690_730
@@ -49,6 +52,7 @@ defmodule Discovergy.MetadataTest do
                 first_measurement_time: 1_563_286_659_367,
                 full_serial_number: "1ESY1161229886",
                 internal_meters: 1,
+                kwh_scaling_factor: 10_000_000_000,
                 last_measurement_time: 1_594_130_690_730,
                 load_profile_type: "SLP",
                 location: %Discovergy.Location{
@@ -61,8 +65,10 @@ defmodule Discovergy.MetadataTest do
                 manufacturer_id: "ESY",
                 measurement_type: "ELECTRICITY",
                 meter_id: "c1972a89ce3a4d58aadcb7908a1d31c7",
+                printed_full_serial_number: "1ESY1161229886",
                 scaling_factor: 1,
                 serial_number: "61229886",
+                submeter: false,
                 type: "EASYMETER",
                 voltage_scaling_factor: 1
               }

--- a/test/discovergy/virtual_meters_test.exs
+++ b/test/discovergy/virtual_meters_test.exs
@@ -14,6 +14,7 @@ defmodule Discovergy.VirtualMetersTest do
             manufacturerId: "ESY",
             serialNumber: "61229886",
             fullSerialNumber: "1ESY1161229886",
+            printedFullSerialNumber: "1ESY1161229886",
             location: %{
               street: "Sedanstr.",
               streetNumber: "8",
@@ -28,6 +29,8 @@ defmodule Discovergy.VirtualMetersTest do
             scalingFactor: 1,
             currentScalingFactor: 1,
             voltageScalingFactor: 1,
+            kWhScalingFactor: 10_000_000_000,
+            submeter: false,
             internalMeters: 1,
             firstMeasurementTime: 1_563_286_659_367,
             lastMeasurementTime: 1_594_130_690_730
@@ -43,6 +46,7 @@ defmodule Discovergy.VirtualMetersTest do
                 first_measurement_time: 1_563_286_659_367,
                 full_serial_number: "1ESY1161229886",
                 internal_meters: 1,
+                kwh_scaling_factor: 10_000_000_000,
                 last_measurement_time: 1_594_130_690_730,
                 load_profile_type: "SLP",
                 location: %Discovergy.Location{
@@ -55,8 +59,10 @@ defmodule Discovergy.VirtualMetersTest do
                 manufacturer_id: "ESY",
                 measurement_type: "ELECTRICITY",
                 meter_id: "c1972a89ce3a4d58aadcb7908a1d31c7",
+                printed_full_serial_number: "1ESY1161229886",
                 scaling_factor: 1,
                 serial_number: "61229886",
+                submeter: false,
                 type: "EASYMETER",
                 voltage_scaling_factor: 1
               }

--- a/test/discovergy/virtual_meters_test.exs
+++ b/test/discovergy/virtual_meters_test.exs
@@ -30,6 +30,7 @@ defmodule Discovergy.VirtualMetersTest do
             currentScalingFactor: 1,
             voltageScalingFactor: 1,
             kWhScalingFactor: 10_000_000_000,
+            storageNumbers: [1, 7, 14],
             submeter: false,
             internalMeters: 1,
             firstMeasurementTime: 1_563_286_659_367,
@@ -62,6 +63,7 @@ defmodule Discovergy.VirtualMetersTest do
                 printed_full_serial_number: "1ESY1161229886",
                 scaling_factor: 1,
                 serial_number: "61229886",
+                storage_numbers: [1, 7, 14],
                 submeter: false,
                 type: "EASYMETER",
                 voltage_scaling_factor: 1


### PR DESCRIPTION
`/meters` returns four fields that `%Discovergy.Meter{}` didn't model: `submeter`, `kWhScalingFactor`, `printedFullSerialNumber` and `storageNumbers`. `Meter.into/1` dropped them silently, since `String.to_existing_atom/1` raised, the rescue kept the key as a string, and `struct/2` skips non-atom keys. No crash, just missing data.

`kWhScalingFactor` needs its own clause in `into/1` next to the existing `location` one, because `Macro.underscore/1` turns it into `"k_wh_scaling_factor"` and that never matches the field name. The other three go through the generic path unchanged.

`storageNumbers` only turned up via the public demo account, which has four meters against my one. Three of them return it, my own meter doesn't, so it parses to `nil` when absent.

Two smaller fixes riding along:

- `Discovergy.Measurement`'s `values` was typed `[map]`, but `into/1` assigns the raw map through and the API returns an object. Now `map`.
- The disaggregation endpoints reject intervals longer than a week with a `400`. The API enforces it, the docs never said so, now they do.

Verified against both the demo and a real account: all four fields parse, and no field on the struct is left `nil` for a payload that populates it.

Came out of #93, which was a misfiled bug report for the [ioBroker adapter](https://github.com/DrozmotiX/ioBroker.discovergy) but pointed at a real gap here.