### PR TITLE
Remove get_raw_load_profile/3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking Changes
 
+- Remove `Discovergy.Measurements.get_raw_load_profile/3`. The `/raw_load_profile` endpoint no longer exists and the API returns a 404 for every request, so the function could not succeed.
 - Require Elixir 1.15. The `finch`, `mint` and `hpax` releases carrying the fixes for [CVE-2026-58226](https://osv.dev/vulnerability/EEF-CVE-2026-58226), [CVE-2026-49754](https://osv.dev/vulnerability/EEF-CVE-2026-49754) and [CVE-2026-48862](https://osv.dev/vulnerability/EEF-CVE-2026-48862) no longer compile on older versions.
 
 ### Bug Fixes

--- a/lib/discovergy/measurements.ex
+++ b/lib/discovergy/measurements.ex
@@ -227,38 +227,4 @@ defmodule Discovergy.Measurements do
 
     Client.get(client, "/load_profile", query: parameters)
   end
-
-  @doc """
-  Return the raw, unmodified load profile file as sent by the specified RLM
-  meter on the specified date.
-
-  ## Examples
-
-      iex> {:ok, <<2, profile::binary>>} =
-      ...>   Discovergy.Measurements.get_raw_load_profile(client, meter_id, ~D{2020-07-01})
-      {:ok, <<2, 80, 46, 48, 49, 40, 49, 50, 48, 48, 55, 48, 49, 48, 48, 49,
-      53, 48, 48, 41, 40, 48, 48, 48, 48, 48, 48, 48, 48, 41, 40, 49, 53, 41,
-      40, 56, 41, 40, 49, 46, 50, 57, 41, 40, 107, 87, 104, 41, ...>>}
-
-      iex> String.split(profile)
-      ["P.01(1200701001500)(00000000)(15)(8)(1.29)(kWh)(2.29)(kWh)(3.29)(kvarh)(4.29)...",
-       "(0.0001)(0.0000)(0.0000)(0.0032)(0.0000)(0.0000)(0.0026)(0.0007)",
-       "(0.0000)(0.0000)(0.0000)(0.0035)(0.0000)(0.0000)(0.0029)(0.0005)",
-       "(0.0000)(0.0001)(0.0000)(0.0036)(0.0000)(0.0000)(0.0030)(0.0006)",
-
-  """
-  @spec get_raw_load_profile(Client.t(), Meter.id(), Date.t()) ::
-          {:ok, String.t()} | {:error, Error.t()}
-  def get_raw_load_profile(%Client{} = client, meter_id, date) do
-    {year, month, day} = Date.to_erl(date)
-
-    parameters = [
-      meterId: meter_id,
-      year: year,
-      month: month,
-      day: day
-    ]
-
-    Client.get(client, "/raw_load_profile", query: parameters)
-  end
 end

--- a/test/discovergy/measurements_test.exs
+++ b/test/discovergy/measurements_test.exs
@@ -176,26 +176,4 @@ defmodule Discovergy.MeasurementsTest do
                fields: [:voltage1, :voltage2, :voltage3]
              )
   end
-
-  test "gets load profile", %{client: client} do
-    raw_load_profile =
-      <<2>> <>
-        """
-        P.01(1200601001500)(00000000)(15)(8)(1.29)(kWh)(2.29)(kWh)(3.29)(kvarh)(4.29)(kvarh)(5.29)(kvarh)(6.29)(kvarh)(7.29)(kvarh)(8.2)(kvarh)
-        (0.0000)(0.0000)(0.0000)(0.0035)(0.0000)(0.0000)(0.0031)(0.0004)
-        (0.0001)(0.0001)(0.0000)(0.0035)(0.0000)(0.0000)(0.0031)(0.0005)
-        """
-
-    mock(fn
-      %{
-        method: :get,
-        query: [meterId: "$meter_id", year: "2020", month: "6", day: "1"],
-        url: "https://api.inexogy.com/public/v1/raw_load_profile"
-      } ->
-        json(raw_load_profile)
-    end)
-
-    assert {:ok, raw_load_profile} ==
-             Discovergy.Measurements.get_raw_load_profile(client, "$meter_id", ~D{2020-06-01})
-  end
 end


### PR DESCRIPTION
`/raw_load_profile` no longer exists. Every request gets nginx's own 404 page rather than the plain-text errors the API returns for real failures, which is byte-for-byte what a made-up path like `/definitely_not_an_endpoint` returns. So the request is dying at the routing layer without reaching the application.

Confirmed against both the public demo account and a real one, with `/load_profile` and `/meters` succeeding on the same authenticated client, and with an RLM meter (the only kind the endpoint ever applied to). Auth happens in the application, so a routing-layer 404 can't be an account or permission problem.

Since the function cannot return anything but an error for any input, `@deprecated` would only add a compiler warning to a call that already fails at runtime. Removing it is the honest signal.

Breaking, but the Unreleased section already carries the Elixir 1.15 requirement, so it lands in a release that is breaking regardless.

Found while sweeping every endpoint against the demo account after #102.