### PR TITLE
Add Client.reauthorize/3 to reuse a registered consumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@
 
 ### Changes
 
-- Document the quirks of the API: token expiry, the rate limits on consumer registration and authorization, the shape its errors arrive in, and the undocumented meter fields.
-- Add `Discovergy.Client.refresh/3`, which obtains a new access token while reusing the consumer registered by `login/3`. The API rate limits `consumer_token` requests and asks clients to reuse tokens, so an application that refreshed by calling `login/3` again would eventually be answered with a `429`.
+- Document the quirks of the API: that HTTP Basic auth works and avoids the token lifecycle entirely, token expiry, the rate limits on consumer registration and authorization, the shape its errors arrive in, and the undocumented meter fields.
+- Add `Discovergy.Client.reauthorize/3`, which obtains a new access token while reusing the consumer registered by `login/3`. The API rate limits `consumer_token` requests and asks clients to reuse tokens, so an application that refreshed by calling `login/3` again would eventually be answered with a `429`.
 - Add the `kwh_scaling_factor`, `printed_full_serial_number`, `storage_numbers` and `submeter` fields to `Discovergy.Meter`. The API returns them but they were silently dropped.
 - Fix the `Discovergy.Measurement` typespec: `values` is a map, not a list of maps.
 - Document that the disaggregation endpoints reject intervals longer than one week.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Changes
 
+- Document the quirks of the API: token expiry, the rate limits on consumer registration and authorization, the shape its errors arrive in, and the undocumented meter fields.
 - Add `Discovergy.Client.refresh/3`, which obtains a new access token while reusing the consumer registered by `login/3`. The API rate limits `consumer_token` requests and asks clients to reuse tokens, so an application that refreshed by calling `login/3` again would eventually be answered with a `429`.
 - Add the `kwh_scaling_factor`, `printed_full_serial_number`, `storage_numbers` and `submeter` fields to `Discovergy.Meter`. The API returns them but they were silently dropped.
 - Fix the `Discovergy.Measurement` typespec: `values` is a map, not a list of maps.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Changes
 
+- Add `Discovergy.Client.refresh/3`, which obtains a new access token while reusing the consumer registered by `login/3`. The API rate limits `consumer_token` requests and asks clients to reuse tokens, so an application that refreshed by calling `login/3` again would eventually be answered with a `429`.
 - Add the `kwh_scaling_factor`, `printed_full_serial_number`, `storage_numbers` and `submeter` fields to `Discovergy.Meter`. The API returns them but they were silently dropped.
 - Fix the `Discovergy.Measurement` typespec: `values` is a map, not a list of maps.
 - Document that the disaggregation endpoints reject intervals longer than one week.

--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ iex> {:ok, client} = Discovergy.Client.new() |> Discovergy.Client.login(email, p
 {:ok, %Discovergy.Client{}}
 ```
 
-Access tokens expire. To get a new one, use `Discovergy.Client.refresh/3` rather than logging in again, so the consumer registered by `login/3` is reused:
+Access tokens expire. To get a new one, use `Discovergy.Client.reauthorize/3` rather than logging in again, so the consumer registered by `login/3` is reused:
 
 ```elixir
-iex> {:ok, client} = Discovergy.Client.refresh(client, email, password)
+iex> {:ok, client} = Discovergy.Client.reauthorize(client, email, password)
 {:ok, %Discovergy.Client{}}
 ```
 
-The API rate limits consumer registrations, so an application that refreshes by logging in again is eventually turned away with a `429`.
+The API rate limits consumer registrations, so an application that renews its token by logging in again is eventually turned away with a `429`.
 
 Then pass the `client` to the respective endpoint function. For example, to list all meters the user has access to:
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ iex> Discovergy.Measurements.get_last_reading(client, "c1972a89ce3a4d58aadcb7908
 }}
 ```
 
+## Quirks of the API
+
+The API behaves in ways its [official documentation](https://api.inexogy.com/docs/) does not cover: access tokens expire and come back as a `401` with an empty body, consumer registration and authorization are rate limited per IP, upstream errors arrive as HTML, and `/meters` returns fields that are documented nowhere. Plain HTTP Basic auth also works on every data endpoint, undocumented, which avoids the token lifecycle entirely.
+
+[Quirks of the API](guides/api-quirks.md) collects what running against it turned up.
+
 ## License
 
 This project is Licensed under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ iex> {:ok, client} = Discovergy.Client.new() |> Discovergy.Client.login(email, p
 {:ok, %Discovergy.Client{}}
 ```
 
+Access tokens expire. To get a new one, use `Discovergy.Client.refresh/3` rather than logging in again, so the consumer registered by `login/3` is reused:
+
+```elixir
+iex> {:ok, client} = Discovergy.Client.refresh(client, email, password)
+{:ok, %Discovergy.Client{}}
+```
+
+The API rate limits consumer registrations, so an application that refreshes by logging in again is eventually turned away with a `429`.
+
 Then pass the `client` to the respective endpoint function. For example, to list all meters the user has access to:
 
 ```elixir

--- a/guides/api-quirks.md
+++ b/guides/api-quirks.md
@@ -4,9 +4,39 @@ Behaviour of the Discovergy (inexogy) API that the [official
 documentation](https://api.inexogy.com/docs/) does not cover, collected from
 running against it. Worth reading before deploying anything long-lived.
 
+## HTTP Basic auth works, and is not documented anywhere
+
+Every data endpoint accepts plain HTTP Basic auth with the account's email and
+password:
+
+```
+curl -u 'demo@inexogy.com:demo' https://api.inexogy.com/public/v1/meters
+```
+
+Verified against `meters`, `field_names`, `last_reading`, `devices` and
+`statistics`, all returning `200`. Without credentials, or with a wrong
+password, the same request is a `401`.
+
+This matters because it sidesteps everything below about tokens: nothing to
+expire, no consumer to register, and neither of the rate limits. The
+[ioBroker adapter](https://github.com/DrozmotiX/ioBroker.discovergy) has used
+it exclusively for years.
+
+This library uses OAuth 1.0a, which the official documentation describes as the
+way in. Basic auth is undocumented, so it carries the risk that anything
+undocumented does: it could be withdrawn without notice. The token behaviour
+below applies whenever OAuth is used.
+
+## A public demo account exists
+
+`demo@inexogy.com` / `demo`, with four meters covering electricity, gas and an
+RLM meter. Useful for reproducing behaviour that a single-meter account cannot
+show, such as the `storageNumbers` field, which some meters return and others
+do not.
+
 ## Access tokens expire
 
-They do, and not on a fixed schedule. Intervals observed in production ranged
+Using OAuth, they do, and not on a fixed schedule. Intervals observed in production ranged
 from a few seconds to roughly 24 hours, with a cluster of expiries between
 03:53 and 03:55 on separate days that looks like nightly maintenance.
 
@@ -24,7 +54,7 @@ case Discovergy.Measurements.get_last_reading(client, meter_id) do
     handle(measurement)
 
   {:error, %Discovergy.Error{response: {401, _, _}}} ->
-    Discovergy.Client.refresh(client, email, password)
+    Discovergy.Client.reauthorize(client, email, password)
 
   {:error, error} ->
     handle_error(error)
@@ -43,7 +73,7 @@ second consecutive failure onwards.
 `/oauth1/authorize` takes the email and password directly as query parameters
 rather than redirecting the user to log in at the provider. So getting a new
 access token always requires the user's credentials, and an application that
-refreshes unattended has to keep them.
+renews its token unattended has to keep them.
 
 This is unlike ordinary OAuth 1.0a, where authorization is a browser redirect
 and the client never sees the password, and unlike OAuth 2.0, whose
@@ -59,7 +89,7 @@ accounts does not lift them.
 429 Too Many Requests: Rate of authorize requests from <ip> is too high.
 ```
 
-Use `Discovergy.Client.refresh/3` rather than `Discovergy.Client.login/3` to
+Use `Discovergy.Client.reauthorize/3` rather than `Discovergy.Client.login/3` to
 renew a token. It reuses the consumer registered by the first login and never
 calls `consumer_token`. The consumer can also be persisted and handed back to
 `Discovergy.Client.new/1` so it survives a restart:

--- a/guides/api-quirks.md
+++ b/guides/api-quirks.md
@@ -1,0 +1,111 @@
+# Quirks of the API
+
+Behaviour of the Discovergy (inexogy) API that the [official
+documentation](https://api.inexogy.com/docs/) does not cover, collected from
+running against it. Worth reading before deploying anything long-lived.
+
+## Access tokens expire
+
+They do, and not on a fixed schedule. Intervals observed in production ranged
+from a few seconds to roughly 24 hours, with a cluster of expiries between
+03:53 and 03:55 on separate days that looks like nightly maintenance.
+
+Treat expiry as something that can happen at any moment rather than something
+to pre-empt with a timer.
+
+## An expired token is a 401 with an empty body
+
+The API sends no body with it, so `Discovergy.Error` carries `reason: :unknown`
+rather than a message. Match on the status, never on the reason:
+
+```elixir
+case Discovergy.Measurements.get_last_reading(client, meter_id) do
+  {:ok, measurement} ->
+    handle(measurement)
+
+  {:error, %Discovergy.Error{response: {401, _, _}}} ->
+    Discovergy.Client.refresh(client, email, password)
+
+  {:error, error} ->
+    handle_error(error)
+end
+```
+
+## Re-authenticating on a 401 needs a backoff
+
+A freshly issued token can be rejected within seconds of being issued. A
+handler that re-authenticates on every 401 without backing off will hot loop
+against `authorize`, which is rate limited (see below). Back off from the
+second consecutive failure onwards.
+
+## There is no credential-free refresh
+
+`/oauth1/authorize` takes the email and password directly as query parameters
+rather than redirecting the user to log in at the provider. So getting a new
+access token always requires the user's credentials, and an application that
+refreshes unattended has to keep them.
+
+This is unlike ordinary OAuth 1.0a, where authorization is a browser redirect
+and the client never sees the password, and unlike OAuth 2.0, whose
+`refresh_token` grant needs no credentials at all.
+
+## Consumer registration and authorization are rate limited per IP
+
+Both limits are keyed to the source address, not the account, so switching
+accounts does not lift them.
+
+```
+429 Too Many Requests: Rate of consumer_token requests from <ip> is too high. Please reuse tokens!
+429 Too Many Requests: Rate of authorize requests from <ip> is too high.
+```
+
+Use `Discovergy.Client.refresh/3` rather than `Discovergy.Client.login/3` to
+renew a token. It reuses the consumer registered by the first login and never
+calls `consumer_token`. The consumer can also be persisted and handed back to
+`Discovergy.Client.new/1` so it survives a restart:
+
+```elixir
+{:ok, client} = Discovergy.Client.new() |> Discovergy.Client.login(email, password)
+
+# persist client.consumer and client.token, then later:
+client = Discovergy.Client.new(consumer: consumer, token: token)
+```
+
+`authorize` is limited more tightly than `consumer_token`. Two calls in quick
+succession from one address are enough to trigger it.
+
+## Upstream errors arrive as HTML
+
+A failing upstream returns nginx's own error page rather than JSON or the
+plain-text errors the API produces itself, so `Error.reason` is a screenful of
+HTML. Lead with the status when logging, or the message buries everything
+around it:
+
+```elixir
+case error.response do
+  {status, _, _} -> "HTTP #{status}: #{String.slice(Exception.message(error), 0, 120)}"
+  nil -> Exception.message(error)
+end
+```
+
+A routing-layer 404 in this form, rather than the API's plain-text `404`, means
+the endpoint itself is gone.
+
+## The meter schema is undocumented and grows
+
+`/meters` returns fields the documentation never lists, and new ones appear
+without notice. `Discovergy.Meter` ignores anything it does not model, so an
+unknown field is dropped rather than raising, but it will not be available
+until the struct catches up.
+
+Which fields come back also varies by meter: `storageNumbers` is present on
+some and absent on others.
+
+## Disaggregation is capped at one week
+
+`Discovergy.Disaggregation.get_energy_by_device_measurements/4` and
+`get_activities/4` reject anything longer:
+
+```
+400 Bad Request: Duration of the data cannot be larger than 1 week
+```

--- a/lib/discovergy/client.ex
+++ b/lib/discovergy/client.ex
@@ -3,8 +3,8 @@ defmodule Discovergy.Client do
   A Discovergy API Client
 
   Access tokens expire, and an expired one comes back as a `401` with an empty
-  body. Use `refresh/3` rather than `login/3` to renew one: the API rate limits
-  consumer registration and asks clients to reuse tokens.
+  body. Use `reauthorize/3` rather than `login/3` to get a new one: the API
+  rate limits consumer registration and asks clients to reuse tokens.
 
   See [Quirks of the API](api-quirks.md) for the behaviour this library has to
   work around.
@@ -72,24 +72,27 @@ defmodule Discovergy.Client do
   once a client registers too often.
 
   Prefer this over calling `login/3` again when an access token expires. A
-  long-running application that signs in once and refreshes on every `401`
+  long-running application that signs in once and reauthorizes on every `401`
   registers a single consumer for its lifetime.
+
+  Named for what it does: the API has no credential-free refresh, so this needs
+  the user's password just as `login/3` does. Only the consumer is spared.
 
   ## Examples
 
-      iex> {:ok, client} = Discovergy.Client.refresh(client, email, password)
+      iex> {:ok, client} = Discovergy.Client.reauthorize(client, email, password)
       {:ok, %Discovergy.Client{}}
 
   """
-  @spec refresh(t, String.t(), String.t()) :: {:ok, t} | {:error, Error.t()}
-  def refresh(%__MODULE__{consumer: nil}, email, password)
+  @spec reauthorize(t, String.t(), String.t()) :: {:ok, t} | {:error, Error.t()}
+  def reauthorize(%__MODULE__{consumer: nil}, email, password)
       when is_binary(email) and is_binary(password) do
     {:error, %Error{reason: :not_logged_in}}
   end
 
-  def refresh(%__MODULE__{consumer: consumer} = client, email, password)
+  def reauthorize(%__MODULE__{consumer: consumer} = client, email, password)
       when is_binary(email) and is_binary(password) do
-    with {:ok, token} <- OAuth.refresh(client, consumer, email, password) do
+    with {:ok, token} <- OAuth.reauthorize(client, consumer, email, password) do
       {:ok, %__MODULE__{client | token: token}}
     end
   end

--- a/lib/discovergy/client.ex
+++ b/lib/discovergy/client.ex
@@ -1,6 +1,13 @@
 defmodule Discovergy.Client do
   @moduledoc """
   A Discovergy API Client
+
+  Access tokens expire, and an expired one comes back as a `401` with an empty
+  body. Use `refresh/3` rather than `login/3` to renew one: the API rate limits
+  consumer registration and asks clients to reuse tokens.
+
+  See [Quirks of the API](api-quirks.md) for the behaviour this library has to
+  work around.
   """
 
   alias Discovergy.{Config, OAuth, Error}

--- a/lib/discovergy/client.ex
+++ b/lib/discovergy/client.ex
@@ -51,13 +51,39 @@ defmodule Discovergy.Client do
   @spec login(t, String.t(), String.t()) :: {:ok, t} | {:error, Error.t()}
   def login(%__MODULE__{} = client, email, password)
       when is_binary(email) and is_binary(password) do
-    # The consumer_token and authorize requests have to go out unsigned, and
-    # build_request/5 falls back to the client's credentials, so without this a
-    # client that had logged in before could never log in again.
-    client = %__MODULE__{client | consumer: nil, token: nil}
-
     with {:ok, {consumer, token}} <- OAuth.login(client, email, password) do
       {:ok, %__MODULE__{client | token: token, consumer: consumer}}
+    end
+  end
+
+  @doc """
+  Obtains a new access token for a client that is already signed in.
+
+  Reuses the consumer registered by `login/3` rather than registering another
+  one, which is what the API asks for: it rate limits `consumer_token`
+  requests and answers with `429 Too Many Requests: ... Please reuse tokens!`
+  once a client registers too often.
+
+  Prefer this over calling `login/3` again when an access token expires. A
+  long-running application that signs in once and refreshes on every `401`
+  registers a single consumer for its lifetime.
+
+  ## Examples
+
+      iex> {:ok, client} = Discovergy.Client.refresh(client, email, password)
+      {:ok, %Discovergy.Client{}}
+
+  """
+  @spec refresh(t, String.t(), String.t()) :: {:ok, t} | {:error, Error.t()}
+  def refresh(%__MODULE__{consumer: nil}, email, password)
+      when is_binary(email) and is_binary(password) do
+    {:error, %Error{reason: :not_logged_in}}
+  end
+
+  def refresh(%__MODULE__{consumer: consumer} = client, email, password)
+      when is_binary(email) and is_binary(password) do
+    with {:ok, token} <- OAuth.refresh(client, consumer, email, password) do
+      {:ok, %__MODULE__{client | token: token}}
     end
   end
 
@@ -103,8 +129,8 @@ defmodule Discovergy.Client do
 
   defp build_request(%__MODULE__{} = client, method, path, body, opts) do
     query = opts[:query] || []
-    consumer = opts[:consumer] || client.consumer
-    token = opts[:token] || client.token
+    consumer = Keyword.get(opts, :consumer, client.consumer)
+    token = Keyword.get(opts, :token, client.token)
 
     request = %{
       method: method,

--- a/lib/discovergy/oauth.ex
+++ b/lib/discovergy/oauth.ex
@@ -13,7 +13,7 @@ defmodule Discovergy.OAuth do
           {:ok, {Consumer.t(), Token.t()}} | {:error, Error.t()}
   def login(%Client{} = client, email, password) do
     with {:ok, consumer} <- register_consumer(client, @client_id),
-         {:ok, access_token} <- refresh(client, consumer, email, password) do
+         {:ok, access_token} <- reauthorize(client, consumer, email, password) do
       {:ok, {consumer, access_token}}
     end
   end
@@ -60,9 +60,9 @@ defmodule Discovergy.OAuth do
   @doc """
   Authorization steps 2 to 4, for a consumer that is already registered.
   """
-  @spec refresh(Client.t(), Consumer.t(), String.t(), String.t()) ::
+  @spec reauthorize(Client.t(), Consumer.t(), String.t(), String.t()) ::
           {:ok, Token.t()} | {:error, Error.t()}
-  def refresh(%Client{} = client, %Consumer{} = consumer, email, password) do
+  def reauthorize(%Client{} = client, %Consumer{} = consumer, email, password) do
     with {:ok, request_token} <- get_request_token(client, consumer),
          {:ok, grant} <- authorize(client, request_token, email, password) do
       get_access_token(client, consumer, request_token, grant)

--- a/lib/discovergy/oauth.ex
+++ b/lib/discovergy/oauth.ex
@@ -13,9 +13,7 @@ defmodule Discovergy.OAuth do
           {:ok, {Consumer.t(), Token.t()}} | {:error, Error.t()}
   def login(%Client{} = client, email, password) do
     with {:ok, consumer} <- register_consumer(client, @client_id),
-         {:ok, request_token} <- get_request_token(client, consumer),
-         {:ok, grant} <- authorize(client, request_token, email, password),
-         {:ok, access_token} <- get_access_token(client, consumer, request_token, grant) do
+         {:ok, access_token} <- refresh(client, consumer, email, password) do
       {:ok, {consumer, access_token}}
     end
   end
@@ -60,13 +58,28 @@ defmodule Discovergy.OAuth do
   end
 
   @doc """
+  Authorization steps 2 to 4, for a consumer that is already registered.
+  """
+  @spec refresh(Client.t(), Consumer.t(), String.t(), String.t()) ::
+          {:ok, Token.t()} | {:error, Error.t()}
+  def refresh(%Client{} = client, %Consumer{} = consumer, email, password) do
+    with {:ok, request_token} <- get_request_token(client, consumer),
+         {:ok, grant} <- authorize(client, request_token, email, password) do
+      get_access_token(client, consumer, request_token, grant)
+    end
+  end
+
+  @doc """
   Authorization step 1
 
   See the [OAuth 1.0 specification](https://tools.ietf.org/html/rfc5849) for details.
   """
   @spec register_consumer(Client.t(), String.t()) :: {:ok, Consumer.t()} | {:error, Error.t()}
   def register_consumer(%Client{} = client, client_id) do
-    with {:ok, consumer} <- Client.post(client, "/oauth1/consumer_token", [{"client", client_id}]) do
+    opts = [consumer: nil, token: nil]
+
+    with {:ok, consumer} <-
+           Client.post(client, "/oauth1/consumer_token", [{"client", client_id}], opts) do
       {:ok, Consumer.into(consumer)}
     end
   end
@@ -79,7 +92,7 @@ defmodule Discovergy.OAuth do
   @spec get_request_token(Client.t(), Consumer.t()) :: {:ok, Token.t()} | {:error, Error.t()}
   def get_request_token(%Client{} = client, %Consumer{} = consumer) do
     with {:ok, request_token} <-
-           Client.post(client, "/oauth1/request_token", [], consumer: consumer) do
+           Client.post(client, "/oauth1/request_token", [], consumer: consumer, token: nil) do
       {:ok, Token.into(request_token)}
     end
   end
@@ -94,7 +107,9 @@ defmodule Discovergy.OAuth do
   def authorize(%Client{} = client, %Token{} = request_token, email, password) do
     query = [email: email, password: password, oauth_token: request_token.oauth_token]
 
-    with {:ok, grant} <- Client.get(client, "/oauth1/authorize", query: query) do
+    opts = [query: query, consumer: nil, token: nil]
+
+    with {:ok, grant} <- Client.get(client, "/oauth1/authorize", opts) do
       {:ok, Grant.into(grant)}
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -39,13 +39,13 @@ defmodule Discovergy.MixProject do
       licenses: ["MIT"],
       maintainers: ["Adrian Kumpf"],
       links: %{"GitHub" => @source_url, "Changelog" => "#{@source_url}/blob/master/CHANGELOG.md"},
-      files: ~w(lib mix.exs README.md LICENSE CHANGELOG.md)
+      files: ~w(lib guides mix.exs README.md LICENSE CHANGELOG.md)
     ]
   end
 
   defp docs do
     [
-      extras: ~w(CHANGELOG.md README.md),
+      extras: ~w(README.md guides/api-quirks.md CHANGELOG.md),
       source_ref: "#{@version}",
       source_url: @source_url,
       main: "readme",
@@ -66,7 +66,7 @@ defmodule Discovergy.MixProject do
           Discovergy.EnergyByDeviceMeasurement
         ]
       ],
-      skip_undefined_reference_warnings_on: ~w(CHANGELOG.md README.md)
+      skip_undefined_reference_warnings_on: ~w(CHANGELOG.md README.md guides/api-quirks.md)
     ]
   end
 end

--- a/test/discovergy/oauth_test.exs
+++ b/test/discovergy/oauth_test.exs
@@ -56,7 +56,7 @@ defmodule Discovergy.OAuthTest do
   end
 
   @tag :logged_in
-  test "refreshes the token without registering another consumer", %{client: client} do
+  test "reauthorizes without registering another consumer", %{client: client} do
     test_pid = self()
 
     mock(fn response ->
@@ -65,7 +65,7 @@ defmodule Discovergy.OAuthTest do
     end)
 
     assert {:ok, %Discovergy.Client{consumer: consumer, token: token}} =
-             Discovergy.Client.refresh(client, "$email", "$password")
+             Discovergy.Client.reauthorize(client, "$email", "$password")
 
     assert consumer == client.consumer
 
@@ -83,7 +83,7 @@ defmodule Discovergy.OAuthTest do
   end
 
   @tag :logged_in
-  test "opens the refresh flow with the right credentials", %{client: client} do
+  test "opens the reauthorization flow with the right credentials", %{client: client} do
     test_pid = self()
 
     mock(fn response ->
@@ -91,7 +91,8 @@ defmodule Discovergy.OAuthTest do
       full_authorization(response)
     end)
 
-    assert {:ok, %Discovergy.Client{}} = Discovergy.Client.refresh(client, "$email", "$password")
+    assert {:ok, %Discovergy.Client{}} =
+             Discovergy.Client.reauthorize(client, "$email", "$password")
 
     # Signed in already, but this one still has to go out unsigned.
     assert_receive {"/public/v1/oauth1/authorize", nil}
@@ -102,9 +103,9 @@ defmodule Discovergy.OAuthTest do
     refute auth =~ "oauth_token="
   end
 
-  test "refuses to refresh a client that is not signed in", %{client: client} do
+  test "refuses to reauthorize a client that is not signed in", %{client: client} do
     assert {:error, %Discovergy.Error{reason: :not_logged_in}} =
-             Discovergy.Client.refresh(client, "$email", "$password")
+             Discovergy.Client.reauthorize(client, "$email", "$password")
   end
 
   defp authorization(headers) do

--- a/test/discovergy/oauth_test.exs
+++ b/test/discovergy/oauth_test.exs
@@ -55,6 +55,58 @@ defmodule Discovergy.OAuthTest do
     assert_receive {"/public/v1/oauth1/authorize", nil}
   end
 
+  @tag :logged_in
+  test "refreshes the token without registering another consumer", %{client: client} do
+    test_pid = self()
+
+    mock(fn response ->
+      send(test_pid, {:path, URI.parse(response.url).path})
+      full_authorization(response)
+    end)
+
+    assert {:ok, %Discovergy.Client{consumer: consumer, token: token}} =
+             Discovergy.Client.refresh(client, "$email", "$password")
+
+    assert consumer == client.consumer
+
+    assert %Discovergy.OAuth.Token{
+             oauth_token: "$access_token",
+             oauth_token_secret: "$access_token_secret"
+           } == token
+
+    assert_receive {:path, "/public/v1/oauth1/request_token"}
+    assert_receive {:path, "/public/v1/oauth1/authorize"}
+    assert_receive {:path, "/public/v1/oauth1/access_token"}
+
+    # The point of the whole exercise: the API rate limits this one.
+    refute_receive {:path, "/public/v1/oauth1/consumer_token"}
+  end
+
+  @tag :logged_in
+  test "opens the refresh flow with the right credentials", %{client: client} do
+    test_pid = self()
+
+    mock(fn response ->
+      send(test_pid, {URI.parse(response.url).path, authorization(response.headers)})
+      full_authorization(response)
+    end)
+
+    assert {:ok, %Discovergy.Client{}} = Discovergy.Client.refresh(client, "$email", "$password")
+
+    # Signed in already, but this one still has to go out unsigned.
+    assert_receive {"/public/v1/oauth1/authorize", nil}
+
+    # Signed as the consumer, and never with the access token being replaced.
+    assert_receive {"/public/v1/oauth1/request_token", auth}
+    assert auth =~ "oauth_consumer_key="
+    refute auth =~ "oauth_token="
+  end
+
+  test "refuses to refresh a client that is not signed in", %{client: client} do
+    assert {:error, %Discovergy.Error{reason: :not_logged_in}} =
+             Discovergy.Client.refresh(client, "$email", "$password")
+  end
+
   defp authorization(headers) do
     Enum.find_value(headers, fn {key, value} ->
       if String.downcase(key) == "authorization", do: value


### PR DESCRIPTION
The API rate limits consumer registration and is explicit about why:

```
429 Too Many Requests: Rate of consumer_token requests from <ip> is too high. Please reuse tokens!
```

Refreshing an expired access token by calling `login/3` again re-runs the whole four-step flow, registering another consumer each time. An application that polls and re-authenticates on every `401` will eventually be turned away. I hit this for real while testing against the demo account.

Reusing a consumer wasn't just undocumented, it was impossible by construction. Only `consumer_token` and `authorize` have to go out unsigned, but neither passed `:consumer`, so `build_request/5` fell back to `client.consumer` and signed them. #101 worked around that by blanking the client at the top of `login/3`, which fixed re-login but discarded the one thing worth keeping.

So each step now states what signs it. `opts[:consumer] || client.consumer` can't express "deliberately unsigned", so it becomes `Keyword.get(opts, :consumer, client.consumer)` and an explicit `nil` wins. That also removes the need for the blanking in `login/3`; the two steps that must be unsigned now say so themselves.

`login/3` is unchanged in behaviour and still registers a consumer. `refresh/3` reuses the one already on the client and runs steps 2 to 4, so a refresh costs three requests instead of four and never touches `consumer_token`.

```elixir
{:ok, client} = Discovergy.Client.new() |> Discovergy.Client.login(email, password)

# on 401, instead of logging in again:
{:ok, client} = Discovergy.Client.refresh(client, email, password)
```

Refreshing a client that was never signed in returns `{:error, %Discovergy.Error{reason: :not_logged_in}}` rather than raising.

Tests cover that a refresh never hits `consumer_token`, that `authorize` still goes out unsigned even though the client now has credentials, and that `request_token` is signed as the consumer but never with the access token being replaced. The #101 regression test is untouched and still passes.

The consumer-reuse mechanism is verified against the live API: steps 2 to 4 against a previously registered consumer mint a working token and list meters with it.