### PR TITLE
Correct and extend the API quirks guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,9 @@
 - Add `Discovergy.Client.reauthorize/3`, which obtains a new access token while reusing the consumer registered by `login/3`. The API rate limits `consumer_token` requests and asks clients to reuse tokens, so an application that refreshed by calling `login/3` again would eventually be answered with a `429`.
 - Add the `kwh_scaling_factor`, `printed_full_serial_number`, `storage_numbers` and `submeter` fields to `Discovergy.Meter`. The API returns them but they were silently dropped.
 - Fix the `Discovergy.Measurement` typespec: `values` is a map, not a list of maps.
-- Document that the disaggregation endpoints reject intervals longer than one week.
+- Document the interval limits of the disaggregation endpoints: `Discovergy.Disaggregation.get_energy_by_device_measurements/4` rejects anything longer than a week, `get_activities/4` anything longer than a month.
+- Document that `DELETE /virtual_meter` answers `501` on every account tried, so a virtual meter cannot be removed through the API and the library offers no `delete_virtual_meter/2`.
+- Document the `:fields` option's two traps: the names `Discovergy.Metadata.get_field_names/2` returns do not all round-trip (`storage` comes back as `storageNumber` from the reading endpoints and as `storage` from `/statistics`), and an unknown name is dropped rather than reported, except on `/statistics`, which answers `500` when every requested name is unknown.
 - Treat any 2xx as a successful response.
 - Bump dependencies
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Access tokens expire. To get a new one, use `Discovergy.Client.reauthorize/3` ra
 
 ```elixir
 iex> {:ok, client} = Discovergy.Client.reauthorize(client, email, password)
-{:ok, %Discovergy.Client{}}
+{:ok, #Discovergy.Client<base_url: "https://api.inexogy.com/public/v1", ...>}
 ```
 
 The API rate limits consumer registrations, so an application that renews its token by logging in again is eventually turned away with a `429`.

--- a/guides/api-quirks.md
+++ b/guides/api-quirks.md
@@ -23,9 +23,10 @@ expire, no consumer to register, and neither of the rate limits. The
 it exclusively for years.
 
 This library uses OAuth 1.0a, which the official documentation describes as the
-way in. Basic auth is undocumented, so it carries the risk that anything
-undocumented does: it could be withdrawn without notice. The token behaviour
-below applies whenever OAuth is used.
+way in, and exposes no way to send Basic auth instead. Basic auth is
+undocumented, so it carries the risk that anything undocumented does: it could
+be withdrawn without notice. Everything below applies whenever OAuth is used,
+which here is always.
 
 ## A public demo account exists
 
@@ -33,6 +34,13 @@ below applies whenever OAuth is used.
 RLM meter. Useful for reproducing behaviour that a single-meter account cannot
 show, such as the `storageNumbers` field, which some meters return and others
 do not.
+
+It is read-only in practice, so `Discovergy.VirtualMeters.create_virtual_meter/3`
+cannot be exercised with it:
+
+```
+403 Forbidden: You do not have permission to create virtual meters
+```
 
 ## Access tokens expire
 
@@ -45,8 +53,9 @@ to pre-empt with a timer.
 
 ## An expired token is a 401 with an empty body
 
-The API sends no body with it, so `Discovergy.Error` carries `reason: :unknown`
-rather than a message. Match on the status, never on the reason:
+The API sends no body with it, so `Discovergy.Error` carries
+`reason: {:http_error, 401}` rather than a message. Match on the status, never
+on the reason:
 
 ```elixir
 case Discovergy.Measurements.get_last_reading(client, meter_id) do
@@ -104,12 +113,16 @@ client = Discovergy.Client.new(consumer: consumer, token: token)
 `authorize` is limited more tightly than `consumer_token`. Two calls in quick
 succession from one address are enough to trigger it.
 
-## Upstream errors arrive as HTML
+## Errors are plain text, except when they are HTML
 
-A failing upstream returns nginx's own error page rather than JSON or the
-plain-text errors the API produces itself, so `Error.reason` is a screenful of
-HTML. Lead with the status when logging, or the message buries everything
-around it:
+The API writes its own errors as `text/plain`, with the status repeated in the
+body: `400 Bad Request: The interval length must not exceed 1 day at this
+resolution`. `Discovergy.Error` puts that whole string in `:reason`, so
+`Exception.message/1` reads well on its own.
+
+The exception is a request nginx answers itself, which comes back as its error
+page and makes `Error.reason` a screenful of HTML. Lead with the status when
+logging, or the message buries everything around it:
 
 ```elixir
 case error.response do
@@ -118,24 +131,98 @@ case error.response do
 end
 ```
 
-A routing-layer 404 in this form, rather than the API's plain-text `404`, means
-the endpoint itself is gone.
+A 404 in that form, rather than the API's own plain-text one, means the request
+never reached the API and the endpoint is gone. The Swagger UI at `/docs/` is
+generated from [`/docs/swagger.json`](https://api.inexogy.com/docs/swagger.json),
+which lists endpoints that answer this way: the whole `Calendar` group
+(`/calendars`, `/calendars/intervals`) is documented but not deployed.
 
 ## The meter schema is undocumented and grows
 
 `/meters` returns fields the documentation never lists, and new ones appear
-without notice. `Discovergy.Meter` ignores anything it does not model, so an
-unknown field is dropped rather than raising, but it will not be available
-until the struct catches up.
+without notice. Against the `Meter` definition in `swagger.json`, the extras
+are currently `kWhScalingFactor` and `submeter`; `Discovergy.Meter` models
+both, as `kwh_scaling_factor` and `submeter`.
+
+`Discovergy.Meter` ignores anything it does not model, so a field added later
+is dropped rather than raising, but it will not be available until the struct
+catches up.
 
 Which fields come back also varies by meter: `storageNumbers` is present on
-some and absent on others.
+some and absent on others, so `nil` there means the meter did not report it
+rather than that it has none.
 
-## Disaggregation is capped at one week
+## `get_field_names/2` does not round-trip into `:fields`
 
-`Discovergy.Disaggregation.get_energy_by_device_measurements/4` and
-`get_activities/4` reject anything longer:
+The names `Discovergy.Metadata.get_field_names/2` returns are not all names the
+reading endpoints answer to, and feeding them straight back is the obvious
+thing to do:
+
+```elixir
+{:ok, names} = Discovergy.Metadata.get_field_names(client, meter_id)
+# ["energy", "power", "power1", "power2", "power3", "energyOut", "storage", "gatewayStatus"]
+
+{:ok, measurement} = Discovergy.Measurements.get_last_reading(client, meter_id, fields: names)
+Map.keys(measurement.values)
+# ["energy", "energyOut", "gatewayStatus", "power", "power1", "power2", "power3", "storageNumber"]
+```
+
+`storage` went in, `storageNumber` came out, and asking for `storageNumber`
+directly returns nothing. `/statistics` keys the same value as `storage`, so
+the name to use depends on the endpoint.
+
+## An unknown field name is not an error
+
+`:fields` entries the meter does not have are dropped, and the reply is a `200`
+without them, so a typo costs you a field rather than raising:
+
+```elixir
+Discovergy.Measurements.get_last_reading(client, meter_id, fields: ["powr"])
+{:ok, %Discovergy.Measurement{values: %{}}}
+```
+
+`/statistics` is the exception, and only when *every* requested field is
+unknown, in which case it fails rather than returning an empty map:
 
 ```
-400 Bad Request: Duration of the data cannot be larger than 1 week
+500 Internal Server Error
+```
+
+One valid field is enough to get a `200` back with the unknown ones dropped.
+
+## `DELETE /virtual_meter` is documented but not implemented
+
+`swagger.json` lists it, and the route is real, but it answers `501` with an
+empty body:
+
+```
+$ curl -u '<email>:<password>' -X DELETE 'https://api.inexogy.com/public/v1/virtual_meter?meterId=000...0'
+HTTP/2 501
+content-length: 0
+```
+
+A `GET` on the same path with the same meter id gets as far as validating it:
+
+```
+400 Bad Request: Unable to find meter with meterId: 000...0
+```
+
+So the request authenticates and routes; it is the `DELETE` handler that is
+missing. Confirmed on two unrelated accounts, so it is not a permission the
+account lacks, which the API reports as a `403` with a message. The empty body
+means this arrives as `reason: {:http_error, 501}`.
+
+There is no `Discovergy.VirtualMeters.delete_virtual_meter/2` because there is
+nothing for it to call. Virtual meters created through
+`create_virtual_meter/3` cannot be removed through the API.
+
+## The two disaggregation endpoints cap the interval differently
+
+`Discovergy.Disaggregation.get_energy_by_device_measurements/4` rejects
+anything longer than a week, `get_activities/4` anything longer than a month.
+The documentation gives neither limit:
+
+```
+400 Bad Request: Duration of the data cannot be larger than 1 week. Please try for a smaller duration.
+400 Bad Request: Duration of the data cannot be larger than 1 month. Please try for a smaller duration.
 ```

--- a/lib/discovergy.ex
+++ b/lib/discovergy.ex
@@ -10,6 +10,13 @@ defmodule Discovergy do
       iex> {:ok, client} = Discovergy.Client.new() |> Discovergy.Client.login(email, password)
       {:ok, #Discovergy.Client<base_url: "https://api.inexogy.com/public/v1", ...>}
 
+  Access tokens expire. Use `Discovergy.Client.reauthorize/3` to get a new one
+  rather than logging in again, so the consumer registered by `login/3` is
+  reused. Consumer registration is rate limited per IP, so an application that
+  renews its token by logging in again is eventually answered with a `429`. See
+  [Quirks of the API](api-quirks.md) for the rest of what running against it
+  turned up.
+
   Then pass the `client` to the respective endpoint function. For example, to list all meters the user has access to:
 
       iex> Discovergy.Metadata.get_meters(client)

--- a/lib/discovergy/client.ex
+++ b/lib/discovergy/client.ex
@@ -38,6 +38,15 @@ defmodule Discovergy.Client do
   - `:base_url` - the base URL for all endpoints (default: `#{@base_url}`)
   - `:http_client` - a module implementing the `Discovergy.HTTPClient`
     behaviour (default: the `:client` application environment setting)
+  - `:consumer` - the consumer of a previous session, taken from
+    `client.consumer` after a `login/3`
+  - `:token` - the access token of a previous session, taken from
+    `client.token`
+
+  Passing `:consumer` and `:token` restores a session that was persisted
+  elsewhere, so a restart neither registers another consumer nor spends an
+  `authorize` call. Both are rate limited per IP. The client is then usable
+  right away, and `reauthorize/3` works on it once the token expires.
 
   ## Examples
 
@@ -92,7 +101,7 @@ defmodule Discovergy.Client do
   ## Examples
 
       iex> {:ok, client} = Discovergy.Client.reauthorize(client, email, password)
-      {:ok, %Discovergy.Client{}}
+      {:ok, #Discovergy.Client<base_url: "https://api.inexogy.com/public/v1", ...>}
 
   """
   @spec reauthorize(t, String.t(), String.t()) :: {:ok, t} | {:error, Error.t()}

--- a/lib/discovergy/disaggregation.ex
+++ b/lib/discovergy/disaggregation.ex
@@ -68,11 +68,11 @@ defmodule Discovergy.Disaggregation do
   Returns the activities recognised for the given meter during the given
   interval.
 
-  The API rejects intervals longer than one week with a `400`.
+  The API rejects intervals longer than one month with a `400`.
 
   ## Examples
 
-      iex> Discovergy.Measurements.get_activities(client, meter_id, from, to)
+      iex> Discovergy.Disaggregation.get_activities(client, meter_id, from, to)
       {:ok, [
         %Discovergy.DisaggregationActivity{
           activity_id: 77,

--- a/lib/discovergy/measurements.ex
+++ b/lib/discovergy/measurements.ex
@@ -29,7 +29,10 @@ defmodule Discovergy.Measurements do
 
     * `:to` - end of the interval. Left to the API if omitted.
     * `:fields` - list of measurement fields to return in the result (use
-    `Discovergy.Metadata.get_field_names/2` to get all available fields)
+    `Discovergy.Metadata.get_field_names/2` to get all available fields). A
+    name the meter does not have is dropped rather than reported, and the
+    names `get_field_names/2` returns do not all round-trip; see [Quirks of
+    the API](api-quirks.md)
     * `:resolution` - time distance between returned readings, see
     `t:resolution/0` (default: `:raw`)
     * `:disaggregation` - Include load disaggregation as pseudo-measurement
@@ -91,7 +94,10 @@ defmodule Discovergy.Measurements do
   ## Options
 
     * `:fields` - list of measurement fields to return in the result (use
-    `Discovergy.Metadata.get_field_names/2` to get all available fields)
+    `Discovergy.Metadata.get_field_names/2` to get all available fields). A
+    name the meter does not have is dropped rather than reported, and the
+    names `get_field_names/2` returns do not all round-trip; see [Quirks of
+    the API](api-quirks.md)
     * `:each` - Return data from the virtual meter itself (false) or all its
     sub-meters (true). Only applies if meterId refers to a virtual meter
 
@@ -134,7 +140,10 @@ defmodule Discovergy.Measurements do
 
     * `:to` - end of the interval. Left to the API if omitted.
     * `:fields` - list of measurement fields to return in the result (use
-    `Discovergy.Metadata.get_field_names/2` to get all available fields)
+    `Discovergy.Metadata.get_field_names/2` to get all available fields). A
+    name the meter does not have is dropped, unless every name is unknown, in
+    which case the endpoint answers `500`; see [Quirks of the
+    API](api-quirks.md)
 
   ## Examples
 

--- a/lib/discovergy/virtual_meters.ex
+++ b/lib/discovergy/virtual_meters.ex
@@ -27,6 +27,10 @@ defmodule Discovergy.VirtualMeters do
   The readings of the meters in `meter_ids_plus` are added up, those in
   `meter_ids_minus` are subtracted.
 
+  There is no way to remove one again: the API documents
+  `DELETE /virtual_meter` but answers `501` to it. See [Quirks of the
+  API](api-quirks.md).
+
   ## Examples
 
       iex> Discovergy.VirtualMeters.create_virtual_meter(client, [meter_id, other_meter_id])


### PR DESCRIPTION
Ran every public function against the public demo account and diffed the endpoint list against [`/docs/swagger.json`](https://api.inexogy.com/docs/swagger.json), which the Swagger UI at `/docs/` is generated from and which is far more complete than the page it renders. The library came through it well: every endpoint works, `Discovergy.Meter` models every field `/meters` currently returns with nothing left over in either direction, and the session round-trip (`login/3` → persist → `new/1` → `reauthorize/3`) behaves as documented. What needed fixing was the documentation.

## Corrections

An expired token carries `reason: {:http_error, 401}`, not `:unknown`. The guide predates the change the changelog already records.

The two disaggregation endpoints do not share a limit. `/disaggregation` rejects intervals longer than a week, `/activities` longer than a month, and each says which in the body. The guide, the `get_activities/4` docstring and the changelog all said one week.

`get_activities/4`'s example called `Discovergy.Measurements`.

Errors are `text/plain`, not HTML. The 400s, the 403, the 429 and the 500 all arrive as plain text with the status repeated in the body. The only HTML is nginx's own error page, which means the request never reached the application, so the section leads with that distinction instead.

The meter fields the documentation omits are now named: against the `Meter` definition in `swagger.json` they are `kWhScalingFactor` and `submeter`, and `Discovergy.Meter` models both.

## New

`get_field_names/2` does not round-trip into `:fields`. `storage` goes in and `storageNumber` comes back from `/readings` and `/last_reading`, while `/statistics` keys the same value as `storage`, so the name to use depends on the endpoint. Feeding the names straight back is the obvious thing to do and it quietly does not work.

An unknown field name is dropped rather than reported, so a typo costs a field silently. `/statistics` is the exception and answers `500` when every requested name is unknown; one valid name is enough for a `200` with the rest dropped. Both are now called out in the `:fields` docs of the three functions that take it, which until now recommended exactly the round-trip that fails.

`DELETE /virtual_meter` is documented but answers `501` with an empty body, while a `GET` on the same path with the same meter id gets as far as validating it (`400 Bad Request: Unable to find meter with meterId: ...`). Confirmed on the demo account and a real one, so it is not a permission the account lacks, which the API reports as a `403` with a message. There is nothing for a `delete_virtual_meter/2` to call, and a virtual meter cannot be removed through the API at all. `create_virtual_meter/3` now says so.

The demo account cannot create virtual meters, which makes `create_virtual_meter/3` the one function it cannot exercise. That is a property of the account rather than of the API, so it sits with the demo account rather than as a quirk of its own.

## Also

`Client.new/1` now documents its `:consumer` and `:token` options, which the guide's restart-persistence recipe and the test suite both rely on but which were undocumented. The two examples showing a client as `%Discovergy.Client{}` are corrected to what the derived `Inspect` actually prints, and the `Discovergy` moduledoc gained the `reauthorize/3` note the README already had.

## Coverage

Nothing reachable is missing. The endpoints in the spec that the library does not wrap are `DELETE /virtual_meter` (501, above), the whole `Calendar` group (`/calendars`, `/calendars/intervals`, which 404 before authentication and so are simply not deployed), and the `POST` write endpoints `/alert`, `/tariff`, `/nilm`, `/disaggregation` and `/readings`, which exist but are for data producers rather than for reading meters. I did not call those, to avoid writing to a shared account.

Docs only, no behaviour changes. `mix format --check-formatted`, `mix compile --warnings-as-errors`, the 37 tests and `mix docs` are all clean.

One thing left open: the guide's first section describes Basic auth as sidestepping the entire token lifecycle, and the library exposes no way to send it. That is a capability gap rather than a documentation one, so it is not in here. A `Client.new(basic_auth: {email, password})` option would be small, at the cost of depending on undocumented behaviour.
