### PR TITLE
Bump the CI lint pair to Elixir 1.20.3 / OTP 29.0.5

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -19,8 +19,8 @@ jobs:
       matrix:
         include:
           - pair:
-              elixir: "1.18.4"
-              otp: "27.3"
+              elixir: "1.20.3"
+              otp: "29.0.5"
             lint: lint
           - pair:
               elixir: "1.15.8"


### PR DESCRIPTION
The newest matrix pair moves from Elixir 1.18.4 / OTP 27.3 to Elixir 1.20.3 / OTP 29.0.5, the current releases of both. Prebuilt artifacts exist for the pair (`v1.20.3-otp-29`, `OTP-29.0.5` on ubuntu-24.04), so `version-type: strict` still resolves.

The older pair stays at Elixir 1.15.8 / OTP 26.2.5 since that guards the `~> 1.15` requirement in mix.exs.

Compiling with `--warnings-as-errors`, `mix format --check-formatted` and the test suite all pass locally on Elixir 1.20 / OTP 29.